### PR TITLE
Add the release HTML URL to outputs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,9 @@ inputs:
     required: false
 env:
   'GITHUB_TOKEN': 'As provided by Github Actions'
+outputs:
+  url:
+    description: 'URL to the Release HTML Page'
 runs:
   using: 'node12'
   main: 'lib/main.js'

--- a/lib/main.js
+++ b/lib/main.js
@@ -29,6 +29,7 @@ function run() {
                 }));
             }
             console.log(`🎉 Release ready at ${rel.html_url}`);
+            core_1.setOutput('url', rel.html_url);
         }
         catch (error) {
             core_1.setFailed(error.message);

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import { paths, parseConfig, isTag } from "./util";
 import { release, upload, GitHubReleaser } from "./github";
-import { setFailed } from "@actions/core";
+import { setFailed, setOutput } from "@actions/core";
 import { GitHub } from "@actions/github";
 import { env } from "process";
 
@@ -18,6 +18,7 @@ async function run() {
       });
     }
     console.log(`🎉 Release ready at ${rel.html_url}`);
+    setOutput('url', rel.html_url);
   } catch (error) {
     setFailed(error.message);
   }


### PR DESCRIPTION
This will allow subsequent actions to get access to the HTML URL for the release created with this. Handy for composing multiple actions together that are related to the release.

In my case I wanted to get the  URL into a slack message posted to the team when a release is published.

The output can be referenced by using the `steps.release.ouput.url` in
the workflow yaml:

    - name: Release
      id: release
      uses: softprops/action-gh-release@v1
      with:
        name: "My Release"
      env:
        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
    - name: Slack
      uses: csexton/slack-message-action@v1
      with:
        message: New release posted at ${{ steps.release.outputs.url}}