### PR TITLE
chore: remove note about github action beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,6 @@
 
 <br />
 
-
-
-> **⚠️ Note:** To use this action, you must have access to the [GitHub Actions](https://github.com/features/actions) feature. GitHub Actions are currently only available in public beta. You can [apply for the GitHub Actions beta here](https://github.com/features/actions/signup/).
-
 ## 🤸 Usage
 
 ### 🚥 Limit releases to pushes to tags


### PR DESCRIPTION
As of 2019-11-13 GitHub Actions is out of beta!
See: https://github.blog/2019-11-13-universe-day-one/#github-actions