### PR TITLE
Only catch github API error

### DIFF
--- a/lib/github.js
+++ b/lib/github.js
@@ -97,13 +97,13 @@ exports.release = (config, releaser) => __awaiter(void 0, void 0, void 0, functi
     }
     catch (error) {
         if (error.status === 404) {
+            const tag_name = tag;
+            const name = config.input_name || tag;
+            const body = util_1.releaseBody(config);
+            const draft = config.input_draft;
+            const prerelease = config.input_prerelease;
+            console.log(`👩‍🏭 Creating new GitHub release for tag ${tag_name}...`);
             try {
-                const tag_name = tag;
-                const name = config.input_name || tag;
-                const body = util_1.releaseBody(config);
-                const draft = config.input_draft;
-                const prerelease = config.input_prerelease;
-                console.log(`👩‍🏭 Creating new GitHub release for tag ${tag_name}...`);
                 let release = yield releaser.createRelease({
                     owner,
                     repo,

--- a/src/github.ts
+++ b/src/github.ts
@@ -136,13 +136,13 @@ export const release = async (
     return release.data;
   } catch (error) {
     if (error.status === 404) {
+      const tag_name = tag;
+      const name = config.input_name || tag;
+      const body = releaseBody(config);
+      const draft = config.input_draft;
+      const prerelease = config.input_prerelease;
+      console.log(`👩‍🏭 Creating new GitHub release for tag ${tag_name}...`);
       try {
-        const tag_name = tag;
-        const name = config.input_name || tag;
-        const body = releaseBody(config);
-        const draft = config.input_draft;
-        const prerelease = config.input_prerelease;
-        console.log(`👩‍🏭 Creating new GitHub release for tag ${tag_name}...`);
         let release = await releaser.createRelease({
           owner,
           repo,


### PR DESCRIPTION
Whenever supplying a non-existing file as `body_path`, the release method will retry indefinitely due the error thrown by `releaseBody`.
Catching errors only within `createRelease` call would correctly throw the error and terminate the script.