### PR TITLE
Make "npm run fmt(check)" work on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   "scripts": {
     "build": "ncc build src/main.ts --minify",
     "test": "jest",
-    "fmt": "prettier --write 'src/**/*.ts' '__tests__/**/*.ts'",
-    "fmtcheck": "prettier --check 'src/**/*.ts' '__tests__/**/*.ts'"
+    "fmt": "prettier --write \"src/**/*.ts\" \"__tests__/**/*.ts\"",
+    "fmtcheck": "prettier --check \"src/**/*.ts\" \"__tests__/**/*.ts\""
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
On Windows, single quotes cannot be used for quoting command line.
Use double quotes instead.