### PR TITLE
Docs: Fix spelling mistakes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,12 +1,12 @@
 ## bootstrapping
 
-This a [JavaScript](https://help.github.com/en/articles/about-actions#types-of-actions)  action but uses [TypeScript](https://www.typescriptlang.org/docs/home.html) to generate that JavaScript.
+This a [JavaScript](https://help.github.com/en/articles/about-actions#types-of-actions) action but uses [TypeScript](https://www.typescriptlang.org/docs/home.html) to generate that JavaScript.
 
-You can bootstrap your envrinment with a modern version of npm and by running `npm i` at the root of this repo.
+You can bootstrap your environment with a modern version of npm and by running `npm i` at the root of this repo.
 
 ## testing
 
-Tests can be found under under `__tests__` directory and are runnable with the `npm t` command
+Tests can be found under under `__tests__` directory and are runnable with the `npm t` command.
 
 ## source code
 
@@ -14,5 +14,4 @@ Source code can be found under the `src` directory. Running `npm run build` will
 
 ## formatting
 
-A minimal attempt at keeping a consistent code style is can be applied by running `npm run fmt`
-
+A minimal attempt at keeping a consistent code style is can be applied by running `npm run fmt`.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 </h1>
 
 <p align="center">
-   A GitHub Action for creating GitHub Releases on Linux, Windows, and OSX virtual environments
+   A GitHub Action for creating GitHub Releases on Linux, Windows, and macOS virtual environments
 </p>
 
 <div align="center">

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 
 Typically usage of this action involves adding a step to a build that
 is gated pushes to git tags. You may find `step.if` field helpful in accomplishing this
-as it maximizes the resuse value of your workflow for non-tag pushes.
+as it maximizes the reuse value of your workflow for non-tag pushes.
 
 Below is a simple example of `step.if` tag gating
 
@@ -75,7 +75,7 @@ jobs:
 
 ### ⬆️ Uploading release assets
 
-You can can configure a number of options for your
+You can configure a number of options for your
 GitHub release and all are optional.
 
 A common case for GitHub releases is to upload your binary after its been validated and packaged.
@@ -202,6 +202,6 @@ The following are *required* as `step.env` keys
 | `GITHUB_TOKEN` | GITHUB_TOKEN as provided by `secrets`|
 
 
-> **⚠️ Note:** This action was previously implemented as a docker container, limiting its use to GitHub Actions Linux virtual environments only. With recent releases, we now support cross platform usage. You'll need to remove the `docker://` prefix in these versions
+> **⚠️ Note:** This action was previously implemented as a Docker container, limiting its use to GitHub Actions Linux virtual environments only. With recent releases, we now support cross platform usage. You'll need to remove the `docker://` prefix in these versions
 
 Doug Tangren (softprops) 2019


### PR DESCRIPTION
## Overview

I was using the repository and noted some spelling mistakes. This PR aims to fix them. Particularly, in the `README.md` and `CONTRIBUTING.md` files.

### README.md

'reuse' instead of 'resuse':

```diff
-as it maximizes the resuse value of your workflow for non-tag pushes.
+as it maximizes the reuse value of your workflow for non-tag pushes.
```

Remove stutter of "can can":

```diff
-You can can configure a number of options for your
+You can configure a number of options for your
```

Capitalize 'Docker':

```diff
-> **⚠️ Note:** This action was previously implemented as a docker container, limiting its use to GitHub Actions Linux virtual environments only. With recent releases, we now support cross platform usage. You'll need to remove the `docker://` prefix in these versions
+> **⚠️ Note:** This action was previously implemented as a Docker container, limiting its use to GitHub Actions Linux virtual environments only. With recent releases, we now support cross platform usage. You'll need to remove the `docker://` prefix in these versions
```

Rename 'OSX' to 'macOS':

```diff
-   A GitHub Action for creating GitHub Releases on Linux, Windows, and OSX virtual environments
+   A GitHub Action for creating GitHub Releases on Linux, Windows, and macOS virtual environments
```

### CONTRIBUTING.md

Additional space removed:

```diff
-This a [JavaScript](https://help.github.com/en/articles/about-actions#types-of-actions)  action but uses [TypeScript](https://www.typescriptlang.org/docs/home.html) to generate that JavaScript.
+This a [JavaScript](https://help.github.com/en/articles/about-actions#types-of-actions) action but uses [TypeScript](https://www.typescriptlang.org/docs/home.html) to generate that JavaScript.
```

End sentences with period:

```diff
-Tests can be found under under `__tests__` directory and are runnable with the `npm t` command
+Tests can be found under under `__tests__` directory and are runnable with the `npm t` command.

-A minimal attempt at keeping a consistent code style is can be applied by running `npm run fmt`
-
+A minimal attempt at keeping a consistent code style is can be applied by running `npm run fmt`.
```

---

Let me know what you think of these changes!