### PR TITLE
Add upload_url as action output

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ The following outputs can be accessed via `${{ steps.<step-id>.outputs }}` from 
 | Name        | Type    | Description                                                     |
 |-------------|---------|-----------------------------------------------------------------|
 | `url`       | String  | Github.com URL for the release                                  |
+| `upload_url`| String  | URL for uploading assets to the release                         |
 
 
 #### environment variables

--- a/action.yml
+++ b/action.yml
@@ -35,6 +35,8 @@ env:
 outputs:
   url:
     description: 'URL to the Release HTML Page'
+  upload_url:
+    description: 'URL for uploading assets to the release'
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/src/main.ts
+++ b/src/main.ts
@@ -55,6 +55,7 @@ async function run() {
     }
     console.log(`🎉 Release ready at ${rel.html_url}`);
     setOutput("url", rel.html_url);
+    setOutput("upload_url", rel.upload_url);
   } catch (error) {
     setFailed(error.message);
   }


### PR DESCRIPTION
Forwarding `upload_url` of a release to the actions output so it can be used by other actions that want to upload assets.