### PR TITLE
Fixes #71: Get the same behavior described in Docs

### DIFF
--- a/__tests__/util.test.ts
+++ b/__tests__/util.test.ts
@@ -58,9 +58,9 @@ describe("util", () => {
         })
       );
     });
-    it("defaults to body when both body and body path are provided", () => {
+    it("defaults to body path when both body and body path are provided", () => {
       assert.equal(
-        "foo",
+        "bar",
         releaseBody({
           github_ref: "",
           github_repository: "",

--- a/src/util.ts
+++ b/src/util.ts
@@ -19,9 +19,9 @@ export interface Config {
 
 export const releaseBody = (config: Config): string | undefined => {
   return (
-    config.input_body ||
     (config.input_body_path &&
-      readFileSync(config.input_body_path).toString("utf8"))
+      readFileSync(config.input_body_path).toString("utf8")) ||
+    config.input_body
   );
 };
 


### PR DESCRIPTION
Fixes #71: Get the same behavior described in Docs
Now trying read `body path` first then falling back on `body`
Also fixes the wrong test unit