### PR TITLE
fix: remove the substring "refs/tags/" in intputs.tag_name

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -142,8 +142,11 @@ export const release = async (
   releaser: Releaser
 ): Promise<Release> => {
   const [owner, repo] = config.github_repository.split("/");
+  // using githu_ref only if input_tag_name is empty or equals to github_ref
   const tag =
-    config.input_tag_name || config.github_ref.replace("refs/tags/", "");
+    !config.input_tag_name || config.input_tag_name === config.github_ref
+      ? config.github_ref.replace("refs/tags/", "")
+      : config.input_tag_name;
   try {
     // you can't get a an existing draft by tag
     // so we must find one in the list of all releases


### PR DESCRIPTION
Currently, when when using github.GITHUB_REF as tag_name, the action
will remove the substring "refs/tags/" which prevents uploading asset

Issues close #86