### PR TITLE
Ignore existing release null body

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -181,7 +181,11 @@ export const release = async (
     }
     const tag_name = tag;
     const name = config.input_name || tag;
-    const body = `${existingRelease.data.body}\n${releaseBody(config)}`;
+    let body: string = "";
+    if (existingRelease.data.body != null) {
+      body += `${existingRelease.data.body}\n`;
+    }
+    body += releaseBody(config);
     const draft = config.input_draft;
     const prerelease = config.input_prerelease;
 


### PR DESCRIPTION
Using the SOLIDSoftworks/semver-tags action will result in a release
created that doesn't contain anything for the release body. The
consequences is that the updated release body will appear to contain the
string `null` followed by a newline and then the release body as
specified for this action.

In such a case it appears to make more sense to ignore the existing
release body should it be currently `null` instead of implicitly
converting it to a string for the updated release body.
