### PR TITLE
Limit the number of retries

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -141,8 +141,16 @@ export const upload = async (
 
 export const release = async (
   config: Config,
-  releaser: Releaser
+  releaser: Releaser,
+  maxRetries: number = 3
 ): Promise<Release> => {
+  if (maxRetries <= 0) {
+    console.log(
+      `❌ Too many retries. Aborting...`
+    );
+    throw new Error("Too many retries.")
+  }
+
   const [owner, repo] = config.github_repository.split("/");
   const tag =
     config.input_tag_name || config.github_ref.replace("refs/tags/", "");
@@ -227,9 +235,9 @@ export const release = async (
       } catch (error) {
         // presume a race with competing metrix runs
         console.log(
-          `⚠️ GitHub release failed with status: ${error.status}, retrying...`
+          `⚠️ GitHub release failed with status: ${error.status}, retrying... (${maxRetries - 1} retries remaining)`
         );
-        return release(config, releaser);
+        return release(config, releaser, maxRetries - 1);
       }
     } else {
       console.log(


### PR DESCRIPTION
Limits the number of retries in the `release` action.

Fixes: #112