### PR TITLE
Use Github token as default

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -33,8 +33,9 @@ inputs:
   target_commitish:
     description: 'Commitish value that determines where the Git tag is created from. Can be any branch or commit SHA.'
     required: false
-env:
-  'GITHUB_TOKEN': 'As provided by Github Actions'
+  github_token:
+    description: 'GitHub Access Token, defaults to: {{ github.token }}'
+    default: '${{ github.token }}'
 outputs:
   url:
     description: 'URL to the Release HTML Page'


### PR DESCRIPTION
To simplify the action, we can add the `Github token` in the default field as an input rather than fetching it via environment variables. This would make the action a bit less verbose for normal use. Now the action will default to `Github token` by default without needing an explicit definition.

Other actions where the similar change was made.

https://github.com/styfle/cancel-workflow-action/pull/46
https://github.com/jwlawson/actions-setup-cmake/pull/5