### PR TITLE
Specify required permissions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,4 +208,15 @@ The following `step.env` keys are allowed as a fallback but deprecated in favor 
 
 > **⚠️ Note:** This action was previously implemented as a Docker container, limiting its use to GitHub Actions Linux virtual environments only. With recent releases, we now support cross platform usage. You'll need to remove the `docker://` prefix in these versions
 
+### Permissions
+
+This Action requires the following permissions on the GitHub integration token:
+
+```yaml
+permissions:
+  contents: write
+```
+
+[GitHub token permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) can be set for an individual job, workflow, or for Actions as a whole.
+
 Doug Tangren (softprops) 2019


### PR DESCRIPTION
I attempted to implement this action and was stymied by the following error:
> Unexpected error fetching GitHub release for tag refs/tags/1.14.0: HttpError: Resource not accessible by integration

Our org had Actions repo access set to read-only. Even knowing that, it wasn't clear what permissions were required to actually fix the actions. Experiments reveal probably just `contents: write`. I'm a little surprised, I would have expected `packages: write` as well?

Downstream issue where we encountered this problem: https://github.com/acquia/cli/pull/654
Previous issue, where this should have been documented more visibly: https://github.com/softprops/action-gh-release/issues/96