### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,14 @@ permissions:
   contents: write
 ```
 
+When used with `discussion_category_name`, additional permission is needed:
+
+```yaml
+permissions:
+  contents: write
+  discussions: write
+```
+
 [GitHub token permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) can be set for an individual job, workflow, or for Actions as a whole.
 
 Doug Tangren (softprops) 2019


### PR DESCRIPTION
Add permissions needed for creating a linked discussion.

The `discussions` scope is, as far as I can tell, not documented, or I just couldn't find it with extensive web searches. GitHub's docs don't seem to mention it anywhere.

However someone knew to add it to the JSON schema:
https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/github-workflow.json#L174-L176

It took a lot of trial and error for me to figure out why my release worked in draft mode but was failing when creating a full release.

The output for this scenario is also very confusing. I was using a token with only the `contents: write` scope, and getting this result:

```
👩‍🏭 Creating new GitHub release for tag v0.2.0...
⚠️ GitHub release failed with status: 404
undefined
retrying... (2 retries remaining)
👩‍🏭 Creating new GitHub release for tag v0.2.0...
⚠️ GitHub release failed with status: 4[22](https://github.com/briantist/CcgVault/runs/6541216512?check_suite_focus=true#step:4:23)
[{"resource":"Release","code":"already_exists","field":"tag_name"}]
retrying... (1 retries remaining)
👩‍🏭 Creating new GitHub release for tag v0.2.0...
⚠️ GitHub release failed with status: 422
[{"resource":"Release","code":"already_exists","field":"tag_name"}]
retrying... (0 retries remaining)
❌ Too many retries. Aborting...
Error: Too many retries.
```

It successfully created the tag, so that was also an orphaned bit that I had to clean up manually before trying to run again (otherwise I would get a 422 immediately).

Then this error:
```
GitHub release failed with status: 404
undefined
```

Really doesn't tell me what's wrong. It then retries, where it hits the 422 errors.

I get that a 404 doesn't say much, but I think generally 404 are not retry-able errors.

I think there's room for improvement, some suggestions:
* try to check for permissions needed before performing the first operation
* keep track of created objects (like tag) and delete them if other errors are found (needs to account for a tag that already existed vs. one created in this run)
* don't retry on 404 (won't solve above issues though)

Hopefully this small documentation change is at least helpful for future users though.
Thank you for your work on this action!
