### PR TITLE
update to node16 from node12 

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -58,7 +58,7 @@ outputs:
   assets:
     description: "JSON array containing information about each uploaded asset, in the format given [here](https://docs.github.com/en/rest/reference/repos#upload-a-release-asset--code-samples) (minus the `uploader` field)"
 runs:
-  using: "node12"
+  using: "node16"
   main: "dist/index.js"
 branding:
   color: "green"


### PR DESCRIPTION
READ: I don't know what implications this could cause for the codebase, I'm really unfamiliar with github-actions repos but this just changes the `run` field in `actions.yml` from `node12` to `node16`, as per [this github blog post](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/).

Closes #263
Closes #249