### PR TITLE
"Let's" → "lets".

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ jobs:
             LICENSE
 ```
 
-> **⚠️ Note:** Notice the `|` in the yaml syntax above ☝️. That let's you effectively declare a multi-line yaml string. You can learn more about multi-line yaml syntax [here](https://yaml-multiline.info)
+> **⚠️ Note:** Notice the `|` in the yaml syntax above ☝️. That lets you effectively declare a multi-line yaml string. You can learn more about multi-line yaml syntax [here](https://yaml-multiline.info)
 
 ### 📝 External release notes
 


### PR DESCRIPTION
Third-person singular simple present form of "let" is obviously intended, judging from grammatical context.
Contraction of "let us" is erroneously used instead.