### PR TITLE
Fix a grammar typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ jobs:
             LICENSE
 ```
 
-> **⚠️ Note:** Notice the `|` in the yaml syntax above ☝️. That let's you effectively declare a multi-line yaml string. You can learn more about multi-line yaml syntax [here](https://yaml-multiline.info)
+> **⚠️ Note:** Notice the `|` in the yaml syntax above ☝️. That lets you effectively declare a multi-line yaml string. You can learn more about multi-line yaml syntax [here](https://yaml-multiline.info)
 
 ### 📝 External release notes
 


### PR DESCRIPTION
The third person `s` for the verb `let` has been mistakenly written as `let's`, which is the abbreviation for `let us`. It should be replaced with `lets`.