### PR TITLE
Do not raise misleading warning

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -60,7 +60,7 @@ async function run() {
     });
     //);
     const rel = await release(config, new GitHubReleaser(gh));
-    if (config.input_files) {
+    if (config.input_files && config.input_files.length > 0) {
       const files = paths(config.input_files);
       if (files.length == 0) {
         console.warn(`🤔 ${config.input_files} not include valid file.`);


### PR DESCRIPTION
When the input `input_files` is not defined, the `config.input_files` will default to an empty array, which always evaluate to true - that was triggering a misleading warning suggesting that the user did input something but the input didn't point to any file.

As a fix, simply check if the array is empty as well :) 