### PR TITLE
fix: support space in file name

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -149,7 +149,7 @@ export const upload = async (
   const [owner, repo] = config.github_repository.split("/");
   const { name, size, mime, data: body } = asset(path);
   const currentAsset = currentAssets.find(
-    ({ name: currentName }) => currentName.replace(' ','.') == name
+    ({ name: currentName }) => currentName == name.replace(' ','.')
   );
   if (currentAsset) {
     console.log(`♻️ Deleting previously uploaded asset ${name}...`);

--- a/src/github.ts
+++ b/src/github.ts
@@ -149,7 +149,7 @@ export const upload = async (
   const [owner, repo] = config.github_repository.split("/");
   const { name, size, mime, data: body } = asset(path);
   const currentAsset = currentAssets.find(
-    ({ name: currentName }) => currentName == name
+    ({ name: currentName }) => currentName.replace(' ','.') == name
   );
   if (currentAsset) {
     console.log(`♻️ Deleting previously uploaded asset ${name}...`);


### PR DESCRIPTION
According to [this issue comment](https://github.com/softprops/action-gh-release/issues/159#issuecomment-949582196), GitHub will rename the asset, which causes the name-based check to fail for file names containing spaces. We can change the file name to the same as GitHub before checking to solve this problem.