### PR TITLE
Feature: add support for release assets with multiple spaces within the name

### DIFF
--- a/__tests__/util.test.ts
+++ b/__tests__/util.test.ts
@@ -6,6 +6,7 @@ import {
   parseInputFiles,
   unmatchedPatterns,
   uploadUrl,
+  alignAssetName
 } from "../src/util";
 import * as assert from "assert";
 
@@ -366,6 +367,20 @@ describe("util", () => {
         unmatchedPatterns(["tests/data/**/*", "tests/data/does/not/exist/*"]),
         ["tests/data/does/not/exist/*"],
       );
+    });
+  });
+
+  describe('replaceSpacesWithDots', () => {
+    it('replaces all spaces with dots', () => {
+        expect(alignAssetName("John Doe.bla")).toBe("John.Doe.bla");
+    });
+
+    it('handles names with multiple spaces', () => {
+        expect(alignAssetName("John William Doe.bla")).toBe("John.William.Doe.bla");
+    });
+
+    it('returns the same string if there are no spaces', () => {
+        expect(alignAssetName("JohnDoe")).toBe("JohnDoe");
     });
   });
 });

--- a/src/github.ts
+++ b/src/github.ts
@@ -1,5 +1,5 @@
 import { GitHub } from "@actions/github/lib/utils";
-import { Config, isTag, releaseBody } from "./util";
+import { Config, isTag, releaseBody, alignAssetName } from "./util";
 import { statSync, readFileSync } from "fs";
 import { getType } from "mime";
 import { basename } from "path";
@@ -166,7 +166,7 @@ export const upload = async (
     // note: GitHub renames asset filenames that have special characters, non-alphanumeric characters, and leading or trailing periods. The "List release assets" endpoint lists the renamed filenames.
     // due to this renaming we need to be mindful when we compare the file name we're uploading with a name github may already have rewritten for logical comparison
     // see https://docs.github.com/en/rest/releases/assets?apiVersion=2022-11-28#upload-a-release-asset
-    ({ name: currentName }) => currentName == name.replace(" ", "."),
+    ({ name: currentName }) => currentName == alignAssetName(name),
   );
   if (currentAsset) {
     console.log(`♻️ Deleting previously uploaded asset ${name}...`);

--- a/src/util.ts
+++ b/src/util.ts
@@ -105,3 +105,7 @@ export const unmatchedPatterns = (patterns: string[]): string[] => {
 export const isTag = (ref: string): boolean => {
   return ref.startsWith("refs/tags/");
 };
+
+export const alignAssetName = (assetName: string): string => {
+  return assetName.replace(/ /g, ".");
+};


### PR DESCRIPTION
This PR improves the Action's ability to handle release assets with names containing two or more spaces. It enhances the functionality for updating existing releases and uploading new assets by correctly identifying and managing all existing release assets, regardless of the number of spaces in their original names.