### PR TITLE
feat: read the release assets asynchronously

### DIFF
--- a/__tests__/github.test.ts
+++ b/__tests__/github.test.ts
@@ -1,6 +1,5 @@
-//import * as assert from "assert";
-//const assert = require('assert');
 import * as assert from "assert";
+import { text } from "stream/consumers";
 import { mimeOrDefault, asset } from "../src/github";
 
 describe("github", () => {
@@ -19,7 +18,7 @@ describe("github", () => {
       assert.equal(name, "bar.txt");
       assert.equal(mime, "text/plain");
       assert.equal(size, 10);
-      assert.equal(data.toString(), "release me");
+      assert.equal(await text(data), "release me");
     });
   });
 });

--- a/src/github.ts
+++ b/src/github.ts
@@ -1,6 +1,6 @@
 import { GitHub } from "@actions/github/lib/utils";
 import { Config, isTag, releaseBody, alignAssetName } from "./util";
-import { statSync, readFileSync } from "fs";
+import { createReadStream, statSync, type ReadStream } from "fs";
 import { getType } from "mime";
 import { basename } from "path";
 
@@ -10,7 +10,7 @@ export interface ReleaseAsset {
   name: string;
   mime: string;
   size: number;
-  data: Buffer;
+  data: ReadStream;
 }
 
 export interface Release {
@@ -145,7 +145,7 @@ export const asset = (path: string): ReleaseAsset => {
     name: basename(path),
     mime: mimeOrDefault(path),
     size: statSync(path).size,
-    data: readFileSync(path),
+    data: createReadStream(path, "binary"),
   };
 };
 


### PR DESCRIPTION
Previously all assets were being read synchronously into memory, making the action unsuitable for releasing very large assets. Because the client library allows stream body inputs (it just forwards it to the underlying `fetch` implementation), just do it.

Fixes: #353