### PR TITLE
chore: simplify ref_type test

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Release
         uses: softprops/action-gh-release@v2
-        if: startsWith(github.ref, 'refs/tags/')
+        if: github.ref_type == 'tag'
 ```
 
 You can also use push config tag filter
@@ -106,7 +106,7 @@ jobs:
         run: cat Release.txt
       - name: Release
         uses: softprops/action-gh-release@v2
-        if: startsWith(github.ref, 'refs/tags/')
+        if: github.ref_type == 'tag'
         with:
           files: Release.txt
 ```
@@ -130,7 +130,7 @@ jobs:
         run: cat Release.txt
       - name: Release
         uses: softprops/action-gh-release@v2
-        if: startsWith(github.ref, 'refs/tags/')
+        if: github.ref_type == 'tag'
         with:
           files: |
             Release.txt
@@ -162,7 +162,7 @@ jobs:
         run: echo "# Good things have arrived" > ${{ github.workspace }}-CHANGELOG.txt
       - name: Release
         uses: softprops/action-gh-release@v2
-        if: startsWith(github.ref, 'refs/tags/')
+        if: github.ref_type == 'tag'
         with:
           body_path: ${{ github.workspace }}-CHANGELOG.txt
           repository: my_gh_org/my_gh_repo


### PR DESCRIPTION
Replaces `startsWith(github.ref, 'refs/tags/')` with `github.ref_type == 'tag'`.

See the documentation for the `github` context here: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#github-context