### PR TITLE
fix(docs): clarify the default for tag_name

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,7 +13,7 @@ inputs:
     description: "Gives the release a custom name. Defaults to tag name"
     required: false
   tag_name:
-    description: "Gives a tag name. Defaults to github.GITHUB_REF"
+    description: "Gives a tag name. Defaults to github.ref_name"
     required: false
   draft:
     description: "Creates a draft release. Defaults to false"


### PR DESCRIPTION
Similar to #544 but for input description in `action.yml`.