### PR TITLE
feat: respect working_directory for files globs; add input and tests

### DIFF
--- a/__tests__/util.test.ts
+++ b/__tests__/util.test.ts
@@ -128,6 +128,7 @@ describe('util', () => {
           github_ref: '',
           github_repository: '',
           github_token: '',
+          input_working_directory: undefined,
           input_append_body: false,
           input_body: undefined,
           input_body_path: undefined,
@@ -156,6 +157,7 @@ describe('util', () => {
           github_ref: '',
           github_repository: '',
           github_token: '',
+          input_working_directory: undefined,
           input_append_body: false,
           input_body: undefined,
           input_body_path: undefined,
@@ -183,6 +185,7 @@ describe('util', () => {
           github_ref: '',
           github_repository: '',
           github_token: '',
+          input_working_directory: undefined,
           input_append_body: false,
           input_body: undefined,
           input_body_path: undefined,
@@ -211,6 +214,7 @@ describe('util', () => {
           github_ref: '',
           github_repository: '',
           github_token: '',
+          input_working_directory: undefined,
           input_append_body: false,
           input_body: undefined,
           input_body_path: undefined,
@@ -243,6 +247,7 @@ describe('util', () => {
           github_ref: '',
           github_repository: '',
           github_token: 'env-token',
+          input_working_directory: undefined,
           input_append_body: false,
           input_body: undefined,
           input_body_path: undefined,
@@ -272,6 +277,7 @@ describe('util', () => {
           github_ref: '',
           github_repository: '',
           github_token: 'input-token',
+          input_working_directory: undefined,
           input_append_body: false,
           input_body: undefined,
           input_body_path: undefined,
@@ -300,6 +306,7 @@ describe('util', () => {
           github_ref: '',
           github_repository: '',
           github_token: '',
+          input_working_directory: undefined,
           input_append_body: false,
           input_body: undefined,
           input_body_path: undefined,
@@ -327,6 +334,7 @@ describe('util', () => {
           github_ref: '',
           github_repository: '',
           github_token: '',
+          input_working_directory: undefined,
           input_append_body: false,
           input_body: undefined,
           input_body_path: undefined,
@@ -354,6 +362,7 @@ describe('util', () => {
           github_ref: '',
           github_repository: '',
           github_token: '',
+          input_working_directory: undefined,
           input_append_body: true,
           input_body: undefined,
           input_body_path: undefined,
@@ -388,6 +397,10 @@ describe('util', () => {
         'tests/data/foo/bar.txt',
       ]);
     });
+
+    it('resolves files relative to working_directory', async () => {
+      assert.deepStrictEqual(paths(['data/**/*'], 'tests'), ['tests/data/foo/bar.txt']);
+    });
   });
 
   describe('unmatchedPatterns', () => {
@@ -396,6 +409,12 @@ describe('util', () => {
         unmatchedPatterns(['tests/data/**/*', 'tests/data/does/not/exist/*']),
         ['tests/data/does/not/exist/*'],
       );
+    });
+
+    it('resolves unmatched relative to working_directory', async () => {
+      assert.deepStrictEqual(unmatchedPatterns(['data/does/not/exist/*'], 'tests'), [
+        'data/does/not/exist/*',
+      ]);
     });
   });
 

--- a/action.yml
+++ b/action.yml
@@ -27,6 +27,9 @@ inputs:
   files:
     description: "Newline-delimited list of path globs for asset files to upload"
     required: false
+  working_directory:
+    description: "Base directory to resolve 'files' globs against (defaults to job working-directory)"
+    required: false
   overwrite_files:
     description: "Overwrite existing files with the same name. Defaults to true"
     required: false

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,7 +12,7 @@ async function run() {
       throw new Error(`⚠️ GitHub Releases requires a tag`);
     }
     if (config.input_files) {
-      const patterns = unmatchedPatterns(config.input_files);
+      const patterns = unmatchedPatterns(config.input_files, config.input_working_directory);
       patterns.forEach((pattern) => {
         if (config.input_fail_on_unmatched_files) {
           throw new Error(`⚠️  Pattern '${pattern}' does not match any files.`);
@@ -50,7 +50,7 @@ async function run() {
     //);
     const rel = await release(config, new GitHubReleaser(gh));
     if (config.input_files && config.input_files.length > 0) {
-      const files = paths(config.input_files);
+      const files = paths(config.input_files, config.input_working_directory);
       if (files.length == 0) {
         if (config.input_fail_on_unmatched_files) {
           throw new Error(`⚠️ ${config.input_files} does not include a valid file.`);


### PR DESCRIPTION
- Add `working_directory` input to resolve file globs relative to a specified base directory instead of always using repo root.
- Updated glob resolution functions to accept and use the working directory parameter for both file matching and unmatched pattern detection.
- Add tests to verify the new behavior works correctly while maintaining backward compatibility.

---

closes: #458, #158