### PR TITLE
fix: pass make_latest to finalizeRelease

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -62,6 +62,7 @@ export interface Releaser {
     owner: string;
     repo: string;
     release_id: number;
+    make_latest: 'true' | 'false' | 'legacy' | undefined;
   }): Promise<{ data: Release }>;
 
   allReleases(params: { owner: string; repo: string }): AsyncIterableIterator<{ data: Release[] }>;
@@ -166,12 +167,18 @@ export class GitHubReleaser implements Releaser {
     return this.github.rest.repos.updateRelease(params);
   }
 
-  async finalizeRelease(params: { owner: string; repo: string; release_id: number }) {
+  async finalizeRelease(params: {
+    owner: string;
+    repo: string;
+    release_id: number;
+    make_latest: 'true' | 'false' | 'legacy' | undefined;
+  }) {
     return await this.github.rest.repos.updateRelease({
       owner: params.owner,
       repo: params.repo,
       release_id: params.release_id,
       draft: false,
+      make_latest: params.make_latest,
     });
   }
 
@@ -389,6 +396,7 @@ export const finalizeRelease = async (
       owner,
       repo,
       release_id: release.id,
+      make_latest: config.input_make_latest,
     });
 
     return data;


### PR DESCRIPTION
## Summary

PR #692 introduced draft-first release creation, but `finalizeRelease` does not pass `make_latest` when updating the release from draft to published. This causes releases to be marked as "latest" despite `make_latest: false` being set.

## Problem

When `make_latest` is omitted from the `updateRelease` call in `finalizeRelease`, GitHub's API defaults to determining "latest" based on semver comparison, ignoring the original `make_latest` setting.

## Fix

Pass `make_latest` through the `finalizeRelease` call chain:
1. Update `Releaser` interface to accept `make_latest` parameter
2. Update `GitHubReleaser.finalizeRelease` to pass `make_latest` to the API
3. Update exported `finalizeRelease` function to pass `config.input_make_latest`

Fixes #703