### PR TITLE
feat: add dependabot cooldown, update pinact annotations

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,8 @@ updates:
       - dependency-name: "@types/node"
         versions:
           - ">=25.0.0"
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: "chore(deps)"
   - package-ecosystem: github-actions
@@ -25,5 +27,7 @@ updates:
       github-actions:
         patterns:
           - "*"
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: "chore(deps)"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v5
 
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version-file: ".tool-versions"
           cache: "npm"


### PR DESCRIPTION
- Add `cooldown: default-days: 7` to both npm and github-actions dependabot ecosystems
- pinact updated setup-node tag comment to `v6.3.0`
- Already on esbuild, no ncc to remove