### PR TITLE
release 3.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,35 @@
+## 3.0.2
+
+`3.0.2` is a patch release focused on release reliability and compatibility. It
+reuses existing draft releases when publishing prereleases, supports replacing
+release assets on Gitea, hardens streamed asset uploads, and provides clearer
+release-creation diagnostics. It also includes TypeScript, coverage, and tooling
+maintenance merged since `3.0.1`.
+
+This release fixes #795, #438, and #803. The upload transport hardening covers the
+historical failure reported in #790, although current hosted Node 24 runners did
+not reproduce it naturally. The diagnostics work is related to #786 and does not
+claim a reproducible release-creation fix.
+
+## What's Changed
+
+### Exciting New Features 🎉
+
+* feat: improve release error reporting and test coverage by @chenrui333 in https://github.com/softprops/action-gh-release/pull/813
+
+### Bug fixes 🐛
+
+* fix: publish existing draft releases as prereleases by @godfengliang in https://github.com/softprops/action-gh-release/pull/801
+* fix: upload small checksum assets reliably by @chenrui333 in https://github.com/softprops/action-gh-release/pull/815
+* fix: replace existing release assets on Gitea by @chenrui333 in https://github.com/softprops/action-gh-release/pull/816
+* fix: clarify release creation 404 errors by @chenrui333 in https://github.com/softprops/action-gh-release/pull/817
+
+### Other Changes 🔄
+
+* chore(deps): upgrade TypeScript to 7 by @chenrui333 in https://github.com/softprops/action-gh-release/pull/812
+* chore(deps): remove unused TypeScript tooling by @chenrui333 in https://github.com/softprops/action-gh-release/pull/814
+* dependency, Node 24 pin, and CI maintenance merged since `3.0.1`
+
 ## 3.0.1
 
 - maintenance release with updated dependencies

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "action-gh-release",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "action-gh-release",
-      "version": "3.0.1",
+      "version": "3.0.2",
       "dependencies": {
         "@actions/core": "^3.0.1",
         "@actions/github": "^9.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "action-gh-release",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "private": true,
   "description": "GitHub Action for creating GitHub Releases",
   "main": "lib/main.js",


### PR DESCRIPTION
## Summary

- bump the package version from 3.0.1 to 3.0.2
- add the v3.0.2 changelog entry
- highlight draft-prerelease reuse, Gitea overwrite compatibility, upload hardening, and improved release diagnostics
- include TypeScript, coverage, and tooling maintenance merged since v3.0.1
- keep source, tests, action metadata, dependency versions, and the generated bundle unchanged

## Release highlights

- publish existing draft releases as prereleases without duplicate releases (#801)
- improve release error reporting and test coverage (#813)
- harden checksum and streamed asset uploads (#815)
- replace existing release assets on Gitea (#816)
- clarify repository-access and discussion-related 404 errors (#817)

## Validation

- `npm ci`
- `npm run fmtcheck`
- `npm run typecheck`
- `npm run build`
- `npm test`
- `npm audit`
- `actionlint -color=false`
- `git diff --exit-code -- dist/index.js`
- `git diff --check`

## Publication

After merge:

1. create annotated tag `v3.0.2` on the merged release commit
2. push `v3.0.2` and require tag CI to pass
3. move floating tag `v3` to the same commit and require its distinct tag CI to pass
4. verify `v2` remains unchanged
5. create the GitHub release from the changelog entry
6. run the exact-version, floating-major, draft-prerelease, Gitea, remote-repository, and linked-discussion harness checks
