### PR TITLE
docs: mark v2 as unsupported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,8 +38,8 @@ claim a reproducible release-creation fix.
 
 `3.0.0` is a major release that moves the action runtime from Node 20 to Node 24.
 Use `v3` on GitHub-hosted runners and self-hosted fleets that already support the
-Node 24 Actions runtime. If you still need the last Node 20-compatible line, stay on
-`v2.6.2`.
+Node 24 Actions runtime. `v2.6.2` was the final Node 20-compatible release and is
+no longer maintained or supported.
 
 ## What's Changed
 
@@ -47,9 +47,12 @@ Node 24 Actions runtime. If you still need the last Node 20-compatible line, sta
 
 * Move the action runtime and bundle target to Node 24
 * Update `@types/node` to the Node 24 line and allow future Dependabot updates
-* Keep the floating major tag on `v3`; `v2` remains pinned to the latest `2.x` release
+* Keep the floating major tag on `v3`; freeze `v2` at the final `v2.6.2` release
 
 ## 2.6.2
+
+`2.6.2` is the final `v2` release and is no longer maintained or supported. Upgrade
+to `v3` for the supported Node 24 runtime and current fixes.
 
 ## What's Changed
 

--- a/README.md
+++ b/README.md
@@ -39,8 +39,11 @@ Typically usage of this action involves adding a step to a build that
 is gated pushes to git tags. You may find `step.if` field helpful in accomplishing this
 as it maximizes the reuse value of your workflow for non-tag pushes.
 
-`v3` requires a GitHub Actions runtime that supports Node 24. If you still need the
-last Node 20-compatible line, stay on `v2.6.2`.
+`v2.6.2` is the final `v2` release and is no longer maintained or supported. It
+uses the [Node 20 runtime deprecated by GitHub Actions](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/).
+Upgrade to `v3`, which runs on Node 24. If a problem still reproduces on the
+latest `v3`, open a new issue with the exact action ref, workflow run URL,
+runner, and relevant logs.
 
 Below is a simple example of `step.if` tag gating
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -36,7 +36,7 @@ Use this checklist when cutting a new `action-gh-release` release.
    - Push only the full version tag first, then wait for its tag-triggered CI to pass.
 9. Move the floating major tag to the same merged release commit.
    - For the current major line, run `npm run updatetag` to move `v3`.
-   - Keep `v2` pinned to the latest `2.x` release for consumers that still need the Node 20 runtime.
+   - Do not move `v2`; it is frozen at the final, unsupported `v2.6.2` release.
    - Verify `v3` and the full version tag are annotated and peel to the same commit.
    - Verify `v2` did not move, then wait for the separate `v3` tag-triggered CI run to pass.
 10. Create the GitHub release from the full version tag.


### PR DESCRIPTION
## Summary

- mark `v2.6.2` as the final, unsupported `v2` release
- recommend upgrading to the maintained Node 24-based `v3` line
- ask users to open a new issue with current `v3` evidence when a problem still reproduces
- freeze the floating `v2` tag at `v2.6.2` in the release checklist

## References

- https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
- https://github.com/softprops/action-gh-release/issues/772
