### PR TITLE
release 3.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## 3.0.3
+
+`3.0.3` is a maintenance release with updated dependencies. It also safely
+classifies malformed GitHub API errors to avoid secondary failures (#822).
+
+## What's Changed
+
+### Bug fixes 🐛
+
+* fix: safely classify GitHub API errors by @chenrui333 in https://github.com/softprops/action-gh-release/pull/822
+
+### Other Changes 🔄
+
+* dependency updates
+
 ## 3.0.2
 
 `3.0.2` is a patch release focused on release reliability and compatibility. It

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "action-gh-release",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "action-gh-release",
-      "version": "3.0.2",
+      "version": "3.0.3",
       "dependencies": {
         "@actions/core": "^3.0.1",
         "@actions/github": "^9.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "action-gh-release",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "private": true,
   "description": "GitHub Action for creating GitHub Releases",
   "main": "lib/main.js",


### PR DESCRIPTION
## Summary

- bump the package version from 3.0.2 to 3.0.3
- add the v3.0.3 changelog entry
- include the GitHub API error-classification fix from #822
- summarize dependency updates merged since v3.0.2

## Notes

After merge, publish annotated tag `v3.0.3`, verify tag CI, move `v3`, verify its separate tag CI, and create the GitHub release from the changelog entry.
